### PR TITLE
Refactor NightForgeDemo into smaller components

### DIFF
--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -1,0 +1,96 @@
+import { Filters } from '@/lib/types';
+import { seedData } from '@/lib/seedData';
+
+interface Props {
+  filters: Filters;
+  setFilters: (f: Filters) => void;
+}
+
+export default function ControlsPanel({ filters, setFilters }: Props) {
+  const handleTreeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFilters({ ...filters, tree: e.target.value });
+  };
+
+  const toggleStatus = () => {
+    setFilters({ ...filters, status: filters.status === 'active' ? 'all' : 'active' });
+  };
+
+  const toggleClusters = () => {
+    setFilters({ ...filters, type: filters.type === 'clusters' ? 'all' : 'clusters' });
+  };
+
+  const toggleAreas = () => {
+    setFilters({ ...filters, type: filters.type === 'areas' ? 'all' : 'areas' });
+  };
+
+  const reset = () => {
+    setFilters({ tree: 'all', status: 'all', type: 'all', search: '' });
+  };
+
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFilters({ ...filters, search: e.target.value });
+  };
+
+  return (
+    <div className="nf-card rounded-lg p-6 mb-8">
+      <h2 className="font-display text-xl font-semibold mb-4">Controls & Filters</h2>
+      <div className="flex flex-wrap gap-4 mb-4">
+        <select
+          id="treeSelect"
+          className="px-4 py-2 rounded-lg border"
+          style={{ background: 'var(--nf-gray-700)', borderColor: 'var(--nf-gray-600)', color: 'var(--nf-gray-200)' }}
+          value={filters.tree}
+          onChange={handleTreeChange}
+        >
+          <option value="all">All Trees</option>
+          {seedData.trees.map((tree) => (
+            <option key={tree.id} value={tree.id}>
+              {tree.name}
+            </option>
+          ))}
+        </select>
+        <button
+          id="filterActive"
+          className={`nf-btn-secondary px-4 py-2 rounded-lg ${filters.status === 'active' ? 'filter-active' : ''}`}
+          onClick={toggleStatus}
+        >
+          Active Only
+        </button>
+        <button
+          id="filterClusters"
+          className={`nf-btn-secondary px-4 py-2 rounded-lg ${filters.type === 'clusters' ? 'filter-active' : ''}`}
+          onClick={toggleClusters}
+        >
+          Clusters
+        </button>
+        <button
+          id="filterAreas"
+          className={`nf-btn-secondary px-4 py-2 rounded-lg ${filters.type === 'areas' ? 'filter-active' : ''}`}
+          onClick={toggleAreas}
+        >
+          Areas
+        </button>
+        <button id="resetFilters" className="nf-btn-primary px-4 py-2 rounded-lg" onClick={reset}>
+          Reset Filters
+        </button>
+      </div>
+      <div className="flex items-center gap-4">
+        <input
+          type="text"
+          id="searchInput"
+          placeholder="Search tags, clusters, areas..."
+          className="px-4 py-2 rounded-lg border flex-1"
+          style={{ background: 'var(--nf-gray-700)', borderColor: 'var(--nf-gray-600)', color: 'var(--nf-gray-200)' }}
+          value={filters.search}
+          onChange={handleSearch}
+        />
+        <button id="expandAll" className="nf-btn-secondary px-4 py-2 rounded-lg">
+          Expand All
+        </button>
+        <button id="collapseAll" className="nf-btn-secondary px-4 py-2 rounded-lg">
+          Collapse All
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DataInspector.tsx
+++ b/src/components/DataInspector.tsx
@@ -1,0 +1,57 @@
+import { FilteredData } from '@/lib/types';
+
+interface Props {
+  data: FilteredData;
+}
+
+export default function DataInspector({ data }: Props) {
+  return (
+    <div className="nf-card rounded-lg p-6">
+      <h2 className="font-display text-xl font-semibold mb-4">Data Inspector</h2>
+      <div id="dataInspector" className="space-y-4">
+        {data.trees.map((tree) => (
+          <div key={tree.id} className="nf-card rounded-lg p-4 mb-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="font-display text-lg font-semibold">{tree.name}</h3>
+              <span className={`tag-badge ${tree.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}`}>{tree.status}</span>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {tree.clusters.map((cluster) => (
+                <div key={cluster.uid} className="border rounded-lg p-3" style={{ borderColor: 'var(--nf-gray-600)' }}>
+                  <div className="flex items-center justify-between mb-2">
+                    <h4 className="font-semibold text-sm">{cluster.name}</h4>
+                    <span className="tag-badge tag-cluster text-xs">{cluster.status}</span>
+                  </div>
+                  <div className="space-y-1">
+                    {data.areas
+                      .filter((a) => a.cluster_uid === cluster.uid)
+                      .map((area) => (
+                        <div key={area.uid}>
+                          <div className="flex items-center justify-between text-xs">
+                            <span style={{ color: 'var(--nf-gray-400)' }}>{area.name}</span>
+                            <span
+                              className={`tag-badge ${area.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}`}
+                              style={{ fontSize: '0.6rem', padding: '0.125rem 0.375rem' }}
+                            >
+                              {area.status}
+                            </span>
+                          </div>
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {area.tags.map((tag) => (
+                              <span key={tag} className="tag-badge tag-area" style={{ fontSize: '0.6rem', padding: '0.125rem 0.25rem' }}>
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/NightForgeDemo.tsx
+++ b/src/components/NightForgeDemo.tsx
@@ -1,461 +1,68 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Script from 'next/script';
+import { Filters, FilteredData } from '@/lib/types';
 import { seedData } from '@/lib/seedData';
-import { Tree, Cluster, Area, TreeNode, FilteredData, Filters } from '@/lib/types';
+import ControlsPanel from './ControlsPanel';
+import StatsDashboard from './StatsDashboard';
+import TreeVisualization from './TreeVisualization';
+import TagCloud from './TagCloud';
+import DataInspector from './DataInspector';
 
 export default function NightForgeDemo() {
-  const [currentFilters, setCurrentFilters] = useState<Filters>({
+  const [filters, setFilters] = useState<Filters>({
     tree: 'all',
     status: 'all',
     type: 'all',
-    search: ''
+    search: '',
   });
   const [isD3Ready, setIsD3Ready] = useState(false);
 
-  useEffect(() => {
-    const d3 = (window as any).d3;
-    if (!d3 || !isD3Ready) return;
+  const filteredData: FilteredData = useMemo(() => {
+    let filteredTrees: any[] = JSON.parse(JSON.stringify(seedData.trees));
+    let filteredAreas: any[] = JSON.parse(JSON.stringify(seedData.areas));
 
-    function getAllClusters(): any[] {
-      return seedData.trees.reduce((acc: any[], tree: any) => acc.concat(tree.clusters), [] as any[]);
+    if (filters.tree !== 'all') {
+      filteredTrees = filteredTrees.filter((t) => t.id === filters.tree);
+      const ids = filteredTrees.reduce((acc: any[], t: any) => acc.concat(t.clusters.map((c: any) => c.uid)), []);
+      filteredAreas = filteredAreas.filter((a: any) => ids.includes(a.cluster_uid));
     }
 
-    function populateTreeSelect() {
-      const select = document.getElementById('treeSelect') as HTMLSelectElement;
-      if (!select) return;
-      
-      // Clear existing options except the first one
-      while (select.children.length > 1) {
-        select.removeChild(select.lastChild!);
-      }
-
-      seedData.trees.forEach((tree) => {
-        const option = document.createElement('option');
-        option.value = tree.id;
-        option.textContent = tree.name;
-        select.appendChild(option);
+    if (filters.status === 'active') {
+      filteredTrees = filteredTrees.filter((t) => t.status === 'active');
+      filteredAreas = filteredAreas.filter((a) => a.status === 'active');
+      filteredTrees.forEach((t) => {
+        t.clusters = t.clusters.filter((c: any) => c.status === 'active');
       });
     }
 
-    function renderStats() {
-      const filteredData = getFilteredData();
-      const activeTags = seedData.tags.filter((t) => t.status === 'active').length;
-      
-      const statTrees = document.getElementById('statTrees') as HTMLElement;
-      const statClusters = document.getElementById('statClusters') as HTMLElement;
-      const statAreas = document.getElementById('statAreas') as HTMLElement;
-      const statTags = document.getElementById('statTags') as HTMLElement;
-
-      if (statTrees) statTrees.textContent = filteredData.trees.length.toString();
-      if (statClusters) statClusters.textContent = filteredData.trees.reduce((acc, tree) => acc + tree.clusters.length, 0).toString();
-      if (statAreas) statAreas.textContent = filteredData.areas.length.toString();
-      if (statTags) statTags.textContent = activeTags.toString();
+    if (filters.type === 'clusters') {
+      filteredAreas = [];
+    } else if (filters.type === 'areas') {
+      filteredTrees.forEach((t) => {
+        t.clusters = t.clusters.filter((c: any) => filteredAreas.some((a: any) => a.cluster_uid === c.uid));
+      });
     }
 
-    function createClusterNode(cluster: any, allClusters: any[], areas: any[]): any {
-      const childClusters = allClusters.filter((c) => c.parent_id === cluster.uid);
-      const clusterAreas = areas.filter((a) => a.cluster_uid === cluster.uid);
-      return {
-        name: cluster.name,
-        type: 'cluster',
-        id: cluster.uid,
-        status: cluster.status,
-        children: [
-          ...childClusters.map((child) => createClusterNode(child, allClusters, areas)),
-          ...clusterAreas.map((area) => ({
-            name: area.name,
-            type: 'area',
-            id: area.uid,
-            status: area.status,
-            tags: area.tags,
-          })),
-        ],
-      };
-    }
-
-    function getFilteredData(): { trees: any[], areas: any[] } {
-      let filteredTrees = JSON.parse(JSON.stringify(seedData.trees));
-      let filteredAreas = JSON.parse(JSON.stringify(seedData.areas));
-
-      if (currentFilters.tree !== 'all') {
-        filteredTrees = filteredTrees.filter((t: any) => t.id === currentFilters.tree);
-        const ids = filteredTrees.reduce((acc: any[], t: any) => acc.concat(t.clusters.map((c: any) => c.uid)), []);
-        filteredAreas = filteredAreas.filter((a: any) => ids.includes(a.cluster_uid));
-      }
-
-      if (currentFilters.status === 'active') {
-        filteredTrees = filteredTrees.filter((t: any) => t.status === 'active');
-        filteredAreas = filteredAreas.filter((a: any) => a.status === 'active');
-        filteredTrees.forEach((t: any) => {
-          t.clusters = t.clusters.filter((c: any) => c.status === 'active');
-        });
-      }
-
-      if (currentFilters.type === 'clusters') {
-        filteredAreas = [];
-      } else if (currentFilters.type === 'areas') {
-        filteredTrees.forEach((t: any) => {
-          t.clusters = t.clusters.filter((c: any) => filteredAreas.some((a: any) => a.cluster_uid === c.uid));
-        });
-      }
-
-      if (currentFilters.search) {
-        const term = currentFilters.search.toLowerCase();
-        filteredAreas = filteredAreas.filter((a: any) =>
+    if (filters.search) {
+      const term = filters.search.toLowerCase();
+      filteredAreas = filteredAreas.filter(
+        (a: any) =>
           a.name.toLowerCase().includes(term) || a.tags.some((tag: string) => tag.toLowerCase().includes(term)),
+      );
+      filteredTrees.forEach((t) => {
+        t.clusters = t.clusters.filter(
+          (c: any) => c.name.toLowerCase().includes(term) || filteredAreas.some((a: any) => a.cluster_uid === c.uid),
         );
-        filteredTrees.forEach((t: any) => {
-          t.clusters = t.clusters.filter(
-            (c: any) => c.name.toLowerCase().includes(term) || filteredAreas.some((a: any) => a.cluster_uid === c.uid),
-          );
-        });
-        filteredTrees = filteredTrees.filter((t: any) => t.name.toLowerCase().includes(term) || t.clusters.length > 0);
-      }
-
-      return { trees: filteredTrees, areas: filteredAreas };
-    }
-
-    function createHierarchicalData() {
-      const filtered = getFilteredData();
-      return {
-        name: 'API Root',
-        type: 'root',
-        children: filtered.trees.map((tree: any) => ({
-          name: tree.name,
-          type: 'tree',
-          id: tree.id,
-          status: tree.status,
-          children: tree.clusters.filter((c: any) => !c.parent_id).map((c: any) => createClusterNode(c, tree.clusters, filtered.areas)),
-        })),
-      };
-    }
-
-    function renderTreeVisualization() {
-      const container = document.getElementById('treeViz') as HTMLElement;
-      if (!container) return;
-      
-      container.innerHTML = '';
-      const width = container.clientWidth;
-      const height = 600;
-      const svg = d3.select('#treeViz').append('svg').attr('width', width).attr('height', height);
-      const g = svg.append('g').attr('transform', 'translate(50,50)');
-      const data = createHierarchicalData();
-      const tree = d3.tree().size([width - 100, height - 100]);
-      const root = d3.hierarchy(data);
-      tree(root);
-      
-      g.selectAll('.tree-link')
-        .data(root.descendants().slice(1))
-        .enter()
-        .append('path')
-        .attr('class', 'tree-link')
-        .attr('d', (d: any) => `M${d.x},${d.y}C${d.x},${(d.y + d.parent.y) / 2} ${d.parent.x},${(d.y + d.parent.y) / 2} ${d.parent.x},${d.parent.y}`);
-
-      const node = g
-        .selectAll('.tree-node')
-        .data(root.descendants())
-        .enter()
-        .append('g')
-        .attr('class', 'tree-node')
-        .attr('transform', (d: any) => `translate(${d.x},${d.y})`);
-
-      node
-        .append('circle')
-        .attr('r', (d: any) => (d.data.type === 'tree' ? 12 : d.data.type === 'cluster' ? 8 : 6))
-        .style('fill', (d: any) => {
-          if (d.data.type === 'tree') return 'var(--nf-primary-500)';
-          if (d.data.type === 'cluster') return 'var(--nf-accent-cyan)';
-          return 'var(--nf-success)';
-        })
-        .style('stroke', 'var(--nf-gray-400)')
-        .style('stroke-width', '2px');
-
-      node
-        .append('text')
-        .attr('dy', (d: any) => (d.data.type === 'tree' ? -18 : -12))
-        .attr('text-anchor', 'middle')
-        .style('fill', 'var(--nf-gray-200)')
-        .style('font-size', (d: any) => (d.data.type === 'tree' ? '14px' : '12px'))
-        .style('font-weight', (d: any) => (d.data.type === 'tree' ? '600' : '400'))
-        .text((d: any) => d.data.name);
-
-      node
-        .filter((d: any) => d.data.status)
-        .append('circle')
-        .attr('r', 3)
-        .attr('cx', 15)
-        .attr('cy', -8)
-        .style('fill', (d: any) => (d.data.status === 'active' ? 'var(--nf-success)' : 'var(--nf-error)'))
-        .style('stroke', 'var(--nf-gray-800)')
-        .style('stroke-width', '1px');
-
-      node.on('click', (_e: any, d: any) => {
-        showNodeDetails(d.data);
       });
+      filteredTrees = filteredTrees.filter(
+        (t: any) => t.name.toLowerCase().includes(term) || t.clusters.length > 0,
+      );
     }
 
-    function renderTagCloud() {
-      const container = document.getElementById('tagCloud') as HTMLElement;
-      if (!container) return;
-      
-      container.innerHTML = '';
-      const filtered = getFilteredData();
-      const tagCounts: Record<string, number> = {};
-      
-      filtered.areas.forEach((area: any) => {
-        area.tags.forEach((tag: string) => {
-          tagCounts[tag] = (tagCounts[tag] || 0) + 1;
-        });
-      });
-      
-      filtered.trees.forEach((tree: any) => {
-        tree.clusters.forEach((cluster: any) => {
-          tagCounts[cluster.name] = (tagCounts[cluster.name] || 0) + 2;
-        });
-      });
-      
-      filtered.areas.forEach((area: any) => {
-        tagCounts[area.name] = (tagCounts[area.name] || 0) + 1;
-      });
-      
-      const sorted = Object.entries(tagCounts)
-        .sort(([, a], [, b]) => b - a)
-        .slice(0, 50);
-        
-      sorted.forEach(([tag, count]) => {
-        const badge = document.createElement('span');
-        badge.className = 'tag-badge';
-        badge.textContent = `${tag} (${count})`;
-        
-        const isCluster = filtered.trees.some((t: any) => t.clusters.some((c: any) => c.name === tag));
-        const isArea = filtered.areas.some((a: any) => a.name === tag);
-        
-        if (isCluster) {
-          badge.classList.add('tag-cluster');
-        } else if (isArea) {
-          badge.classList.add('tag-area');
-        } else {
-          badge.classList.add('tag-status-active');
-        }
-        
-        badge.addEventListener('click', () => {
-          const newFilters = { ...currentFilters, search: tag };
-          setCurrentFilters(newFilters);
-          const input = document.getElementById('searchInput') as HTMLInputElement;
-          if (input) input.value = tag;
-        });
-        
-        container.appendChild(badge);
-      });
-    }
-
-    function renderDataInspector() {
-      const container = document.getElementById('dataInspector') as HTMLElement;
-      if (!container) return;
-      
-      container.innerHTML = '';
-      const filtered = getFilteredData();
-      
-      filtered.trees.forEach((tree: any) => {
-        const card = document.createElement('div');
-        card.className = 'nf-card rounded-lg p-4 mb-4';
-        card.innerHTML = `
-          <div class="flex items-center justify-between mb-3">
-            <h3 class="font-display text-lg font-semibold">${tree.name}</h3>
-            <span class="tag-badge ${tree.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${tree.status}</span>
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            ${tree.clusters
-              .map(
-                (cluster: any) => `
-              <div class="border rounded-lg p-3" style="border-color: var(--nf-gray-600);">
-                <div class="flex items-center justify-between mb-2">
-                  <h4 class="font-semibold text-sm">${cluster.name}</h4>
-                  <span class="tag-badge tag-cluster text-xs">${cluster.status}</span>
-                </div>
-                <div class="space-y-1">
-                  ${filtered.areas
-                    .filter((a: any) => a.cluster_uid === cluster.uid)
-                    .map(
-                      (area: any) => `
-                    <div class="flex items-center justify-between text-xs">
-                      <span style="color: var(--nf-gray-400)">${area.name}</span>
-                      <span class="tag-badge ${area.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}" style="font-size: 0.6rem; padding: 0.125rem 0.375rem;">${area.status}</span>
-                    </div>
-                    <div class="flex flex-wrap gap-1 mt-1">
-                      ${area.tags.map((tag: string) => `<span class="tag-badge tag-area" style="font-size: 0.6rem; padding: 0.125rem 0.25rem;">${tag}</span>`).join('')}
-                    </div>
-                  `,
-                    )
-                    .join('')}
-                </div>
-              </div>
-            `,
-              )
-              .join('')}
-          </div>`;
-        container.appendChild(card);
-      });
-    }
-
-    function showNodeDetails(data: any) {
-      const modal = document.createElement('div');
-      modal.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50';
-      modal.style.backdropFilter = 'blur(8px)';
-      
-      const content = document.createElement('div');
-      content.className = 'nf-card rounded-lg p-6 max-w-2xl w-full mx-4 max-h-96 overflow-y-auto';
-      
-      let details = '';
-      if (data.type === 'tree') {
-        const tree = seedData.trees.find((t) => t.id === data.id)!;
-        details = `
-          <h3 class="font-display text-xl font-semibold mb-4">Tree: ${tree.name}</h3>
-          <div class="space-y-2">
-            <p><strong>ID:</strong> ${tree.id}</p>
-            <p><strong>Status:</strong> <span class="tag-badge ${tree.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${tree.status}</span></p>
-            <p><strong>Created:</strong> ${new Date(tree.created_at).toLocaleString()}</p>
-            <p><strong>Clusters:</strong> ${tree.clusters.length}</p>
-            <p><strong>Total Areas:</strong> ${seedData.areas.filter((a) => tree.clusters.some((c) => c.uid === a.cluster_uid)).length}</p>
-          </div>`;
-      } else if (data.type === 'cluster') {
-        const cluster = getAllClusters().find((c) => c.uid === data.id)!;
-        const areas = seedData.areas.filter((a) => a.cluster_uid === cluster.uid);
-        details = `
-          <h3 class="font-display text-xl font-semibold mb-4">Cluster: ${cluster.name}</h3>
-          <div class="space-y-2">
-            <p><strong>UID:</strong> ${cluster.uid}</p>
-            <p><strong>Status:</strong> <span class="tag-badge ${cluster.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${cluster.status}</span></p>
-            <p><strong>Parent:</strong> ${cluster.parent_id || 'Root'}</p>
-            <p><strong>Children:</strong> ${cluster.children.length}</p>
-            <p><strong>Areas:</strong> ${areas.length}</p>
-            <div class="mt-3">
-              <h4 class="font-semibold mb-2">Areas:</h4>
-              <div class="grid grid-cols-1 gap-2">
-                ${areas
-                  .map(
-                    (area) => `
-                  <div class="border rounded p-2" style="border-color: var(--nf-gray-600);">
-                    <div class="flex justify-between items-center">
-                      <span>${area.name}</span>
-                      <span class="tag-badge ${area.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${area.status}</span>
-                    </div>
-                    <div class="flex flex-wrap gap-1 mt-1">
-                      ${area.tags.map((tag) => `<span class="tag-badge tag-area">${tag}</span>`).join('')}
-                    </div>
-                  </div>`,
-                  )
-                  .join('')}
-              </div>
-            </div>
-          </div>`;
-      } else if (data.type === 'area') {
-        const area = seedData.areas.find((a) => a.uid === data.id)!;
-        details = `
-          <h3 class="font-display text-xl font-semibold mb-4">Area: ${area.name}</h3>
-          <div class="space-y-2">
-            <p><strong>UID:</strong> ${area.uid}</p>
-            <p><strong>Status:</strong> <span class="tag-badge ${area.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${area.status}</span></p>
-            <p><strong>Cluster:</strong> ${area.cluster_uid}</p>
-            <div class="mt-3">
-              <h4 class="font-semibold mb-2">Tags:</h4>
-              <div class="flex flex-wrap gap-1">
-                ${area.tags.map((tag) => `<span class="tag-badge tag-area">${tag}</span>`).join('')}
-              </div>
-            </div>
-          </div>`;
-      }
-      
-      content.innerHTML = `${details}<div class="mt-6 flex justify-end"><button class="nf-btn-primary px-4 py-2 rounded-lg" onclick="this.closest('.fixed').remove()">Close</button></div>`;
-      modal.appendChild(content);
-      document.body.appendChild(modal);
-      
-      modal.addEventListener('click', (e) => {
-        if (e.target === modal) modal.remove();
-      });
-    }
-
-    function updateDisplay() {
-      renderStats();
-      renderTreeVisualization();
-      renderTagCloud();
-      renderDataInspector();
-    }
-
-    function setupEventListeners() {
-      const treeSelect = document.getElementById('treeSelect') as HTMLSelectElement;
-      const filterActive = document.getElementById('filterActive') as HTMLButtonElement;
-      const filterClusters = document.getElementById('filterClusters') as HTMLButtonElement;
-      const filterAreas = document.getElementById('filterAreas') as HTMLButtonElement;
-      const resetFilters = document.getElementById('resetFilters') as HTMLButtonElement;
-      const searchInput = document.getElementById('searchInput') as HTMLInputElement;
-
-      if (treeSelect) {
-        treeSelect.addEventListener('change', (e) => {
-          const newFilters = { ...currentFilters, tree: (e.target as HTMLSelectElement).value };
-          setCurrentFilters(newFilters);
-        });
-      }
-
-      if (filterActive) {
-        filterActive.addEventListener('click', (e) => {
-          const newStatus = currentFilters.status === 'active' ? 'all' : 'active';
-          const newFilters = { ...currentFilters, status: newStatus };
-          setCurrentFilters(newFilters);
-          (e.target as HTMLElement).classList.toggle('filter-active');
-        });
-      }
-
-      if (filterClusters) {
-        filterClusters.addEventListener('click', (e) => {
-          const newType = currentFilters.type === 'clusters' ? 'all' : 'clusters';
-          const newFilters = { ...currentFilters, type: newType };
-          setCurrentFilters(newFilters);
-          (e.target as HTMLElement).classList.toggle('filter-active');
-        });
-      }
-
-      if (filterAreas) {
-        filterAreas.addEventListener('click', (e) => {
-          const newType = currentFilters.type === 'areas' ? 'all' : 'areas';
-          const newFilters = { ...currentFilters, type: newType };
-          setCurrentFilters(newFilters);
-          (e.target as HTMLElement).classList.toggle('filter-active');
-        });
-      }
-
-      if (resetFilters) {
-        resetFilters.addEventListener('click', () => {
-          const newFilters = { tree: 'all', status: 'all', type: 'all', search: '' };
-          setCurrentFilters(newFilters);
-          if (treeSelect) treeSelect.value = 'all';
-          if (searchInput) searchInput.value = '';
-          document.querySelectorAll('.filter-active').forEach((btn) => btn.classList.remove('filter-active'));
-        });
-      }
-
-      if (searchInput) {
-        searchInput.addEventListener('input', (e) => {
-          const newFilters = { ...currentFilters, search: (e.target as HTMLInputElement).value };
-          setCurrentFilters(newFilters);
-        });
-      }
-
-      window.addEventListener('resize', () => {
-        setTimeout(renderTreeVisualization, 100);
-      });
-    }
-
-    function init() {
-      populateTreeSelect();
-      setupEventListeners();
-      updateDisplay();
-    }
-
-    init();
-  }, [currentFilters, isD3Ready]);
+    return { trees: filteredTrees, areas: filteredAreas } as FilteredData;
+  }, [filters]);
 
   const handleD3Load = () => {
     setIsD3Ready(true);
@@ -463,14 +70,13 @@ export default function NightForgeDemo() {
 
   return (
     <>
-      <Script 
-        src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js" 
-        strategy="afterInteractive" 
+      <Script
+        src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"
+        strategy="afterInteractive"
         onLoad={handleD3Load}
       />
       <div className="min-h-screen">
         <div className="container mx-auto px-6 py-8 max-w-7xl">
-          {/* Header */}
           <header className="mb-8">
             <h1 className="font-display text-4xl font-semibold mb-2" style={{ color: 'var(--nf-primary-300)' }}>
               🌑 NightForge Tree API
@@ -480,89 +86,11 @@ export default function NightForgeDemo() {
             </p>
           </header>
 
-          {/* Controls Panel */}
-          <div className="nf-card rounded-lg p-6 mb-8">
-            <h2 className="font-display text-xl font-semibold mb-4">Controls & Filters</h2>
-            <div className="flex flex-wrap gap-4 mb-4">
-              <select 
-                id="treeSelect" 
-                className="px-4 py-2 rounded-lg border" 
-                style={{ background: 'var(--nf-gray-700)', borderColor: 'var(--nf-gray-600)', color: 'var(--nf-gray-200)' }}
-              >
-                <option value="all">All Trees</option>
-              </select>
-              
-              <button id="filterActive" className="nf-btn-secondary px-4 py-2 rounded-lg">
-                Active Only
-              </button>
-              
-              <button id="filterClusters" className="nf-btn-secondary px-4 py-2 rounded-lg">
-                Clusters
-              </button>
-              
-              <button id="filterAreas" className="nf-btn-secondary px-4 py-2 rounded-lg">
-                Areas
-              </button>
-              
-              <button id="resetFilters" className="nf-btn-primary px-4 py-2 rounded-lg">
-                Reset Filters
-              </button>
-            </div>
-            
-            <div className="flex items-center gap-4">
-              <input 
-                type="text" 
-                id="searchInput" 
-                placeholder="Search tags, clusters, areas..." 
-                className="px-4 py-2 rounded-lg border flex-1" 
-                style={{ background: 'var(--nf-gray-700)', borderColor: 'var(--nf-gray-600)', color: 'var(--nf-gray-200)' }} 
-              />
-              <button id="expandAll" className="nf-btn-secondary px-4 py-2 rounded-lg">
-                Expand All
-              </button>
-              <button id="collapseAll" className="nf-btn-secondary px-4 py-2 rounded-lg">
-                Collapse All
-              </button>
-            </div>
-          </div>
-
-          {/* Stats Dashboard */}
-          <div className="stats-grid mb-8">
-            <div className="nf-card rounded-lg p-6">
-              <h3 className="font-display text-lg font-semibold mb-2">Total Trees</h3>
-              <div className="text-3xl font-bold" style={{ color: 'var(--nf-primary-300)' }} id="statTrees">3</div>
-            </div>
-            <div className="nf-card rounded-lg p-6">
-              <h3 className="font-display text-lg font-semibold mb-2">Total Clusters</h3>
-              <div className="text-3xl font-bold" style={{ color: 'var(--nf-accent-cyan)' }} id="statClusters">8</div>
-            </div>
-            <div className="nf-card rounded-lg p-6">
-              <h3 className="font-display text-lg font-semibold mb-2">Total Areas</h3>
-              <div className="text-3xl font-bold" style={{ color: 'var(--nf-success)' }} id="statAreas">30</div>
-            </div>
-            <div className="nf-card rounded-lg p-6">
-              <h3 className="font-display text-lg font-semibold mb-2">Active Tags</h3>
-              <div className="text-3xl font-bold" style={{ color: 'var(--nf-warning)' }} id="statTags">45</div>
-            </div>
-          </div>
-
-          {/* Tree Visualization */}
-          <div className="nf-card rounded-lg p-6 mb-8">
-            <h2 className="font-display text-xl font-semibold mb-4">Tree Structure Visualization</h2>
-            <div id="treeViz" className="w-full" style={{ minHeight: '600px' }}></div>
-          </div>
-
-          {/* Tag Cloud */}
-          <div className="nf-card rounded-lg p-6 mb-8">
-            <h2 className="font-display text-xl font-semibold mb-4">Tag Cloud</h2>
-            <div id="tagCloud" className="flex flex-wrap gap-2"></div>
-          </div>
-
-          {/* Detailed Data View */}
-          <div className="nf-card rounded-lg p-6">
-            <h2 className="font-display text-xl font-semibold mb-4">Data Inspector</h2>
-            <div id="dataInspector" className="space-y-4"></div>
-          </div>
+          <ControlsPanel filters={filters} setFilters={setFilters} />
+          <StatsDashboard data={filteredData} />
+          <TreeVisualization data={filteredData} isD3Ready={isD3Ready} />
+          <TagCloud data={filteredData} filters={filters} setFilters={setFilters} />
+          <DataInspector data={filteredData} />
         </div>
       </div>
     </>

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -1,0 +1,42 @@
+import { FilteredData } from '@/lib/types';
+import { seedData } from '@/lib/seedData';
+
+interface Props {
+  data: FilteredData;
+}
+
+export default function StatsDashboard({ data }: Props) {
+  const activeTags = seedData.tags.filter((t) => t.status === 'active').length;
+  const totalTrees = data.trees.length;
+  const totalClusters = data.trees.reduce((acc, t) => acc + t.clusters.length, 0);
+  const totalAreas = data.areas.length;
+
+  return (
+    <div className="stats-grid mb-8">
+      <div className="nf-card rounded-lg p-6">
+        <h3 className="font-display text-lg font-semibold mb-2">Total Trees</h3>
+        <div className="text-3xl font-bold" style={{ color: 'var(--nf-primary-300)' }} id="statTrees">
+          {totalTrees}
+        </div>
+      </div>
+      <div className="nf-card rounded-lg p-6">
+        <h3 className="font-display text-lg font-semibold mb-2">Total Clusters</h3>
+        <div className="text-3xl font-bold" style={{ color: 'var(--nf-accent-cyan)' }} id="statClusters">
+          {totalClusters}
+        </div>
+      </div>
+      <div className="nf-card rounded-lg p-6">
+        <h3 className="font-display text-lg font-semibold mb-2">Total Areas</h3>
+        <div className="text-3xl font-bold" style={{ color: 'var(--nf-success)' }} id="statAreas">
+          {totalAreas}
+        </div>
+      </div>
+      <div className="nf-card rounded-lg p-6">
+        <h3 className="font-display text-lg font-semibold mb-2">Active Tags</h3>
+        <div className="text-3xl font-bold" style={{ color: 'var(--nf-warning)' }} id="statTags">
+          {activeTags}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TagCloud.tsx
+++ b/src/components/TagCloud.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import { FilteredData, Filters } from '@/lib/types';
+
+interface Props {
+  data: FilteredData;
+  filters: Filters;
+  setFilters: (f: Filters) => void;
+}
+
+export default function TagCloud({ data, filters, setFilters }: Props) {
+  const tagCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    data.areas.forEach((area) => {
+      area.tags.forEach((tag) => {
+        counts[tag] = (counts[tag] || 0) + 1;
+      });
+    });
+    data.trees.forEach((tree) => {
+      tree.clusters.forEach((cluster) => {
+        counts[cluster.name] = (counts[cluster.name] || 0) + 2;
+      });
+    });
+    data.areas.forEach((area) => {
+      counts[area.name] = (counts[area.name] || 0) + 1;
+    });
+    return Object.entries(counts)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 50);
+  }, [data]);
+
+  const handleClick = (tag: string) => {
+    setFilters({ ...filters, search: tag });
+  };
+
+  const isCluster = (tag: string) => data.trees.some((t) => t.clusters.some((c) => c.name === tag));
+  const isArea = (tag: string) => data.areas.some((a) => a.name === tag);
+
+  return (
+    <div className="nf-card rounded-lg p-6 mb-8">
+      <h2 className="font-display text-xl font-semibold mb-4">Tag Cloud</h2>
+      <div id="tagCloud" className="flex flex-wrap gap-2">
+        {tagCounts.map(([tag, count]) => (
+          <span
+            key={tag}
+            className={`tag-badge ${isCluster(tag) ? 'tag-cluster' : isArea(tag) ? 'tag-area' : 'tag-status-active'}`}
+            onClick={() => handleClick(tag)}
+          >
+            {tag} ({count})
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TreeVisualization.tsx
+++ b/src/components/TreeVisualization.tsx
@@ -1,0 +1,207 @@
+import { useEffect } from 'react';
+import { FilteredData, TreeNode } from '@/lib/types';
+import { seedData } from '@/lib/seedData';
+
+interface Props {
+  data: FilteredData;
+  isD3Ready: boolean;
+}
+
+export default function TreeVisualization({ data, isD3Ready }: Props) {
+  useEffect(() => {
+    if (!isD3Ready) return;
+    const d3 = (window as any).d3;
+    if (!d3) return;
+
+    function getAllClusters() {
+      return seedData.trees.reduce((acc: any[], tree: any) => acc.concat(tree.clusters), [] as any[]);
+    }
+
+    function createClusterNode(cluster: any, allClusters: any[], areas: any[]): TreeNode {
+      const childClusters = allClusters.filter((c) => c.parent_id === cluster.uid);
+      const clusterAreas = areas.filter((a) => a.cluster_uid === cluster.uid);
+      return {
+        name: cluster.name,
+        type: 'cluster',
+        id: cluster.uid,
+        status: cluster.status,
+        children: [
+          ...childClusters.map((child) => createClusterNode(child, allClusters, areas)),
+          ...clusterAreas.map((area) => ({
+            name: area.name,
+            type: 'area',
+            id: area.uid,
+            status: area.status,
+            tags: area.tags,
+          })),
+        ],
+      } as TreeNode;
+    }
+
+    function createHierarchicalData() {
+      return {
+        name: 'API Root',
+        type: 'root',
+        children: data.trees.map((tree: any) => ({
+          name: tree.name,
+          type: 'tree',
+          id: tree.id,
+          status: tree.status,
+          children: tree.clusters.filter((c: any) => !c.parent_id).map((c: any) => createClusterNode(c, tree.clusters, data.areas)),
+        })),
+      } as TreeNode;
+    }
+
+    function showNodeDetails(node: any) {
+      const modal = document.createElement('div');
+      modal.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50';
+      modal.style.backdropFilter = 'blur(8px)';
+
+      const content = document.createElement('div');
+      content.className = 'nf-card rounded-lg p-6 max-w-2xl w-full mx-4 max-h-96 overflow-y-auto';
+
+      let details = '';
+      if (node.type === 'tree') {
+        const tree = seedData.trees.find((t) => t.id === node.id)!;
+        details = `
+          <h3 class="font-display text-xl font-semibold mb-4">Tree: ${tree.name}</h3>
+          <div class="space-y-2">
+            <p><strong>ID:</strong> ${tree.id}</p>
+            <p><strong>Status:</strong> <span class="tag-badge ${tree.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${tree.status}</span></p>
+            <p><strong>Created:</strong> ${new Date(tree.created_at).toLocaleString()}</p>
+            <p><strong>Clusters:</strong> ${tree.clusters.length}</p>
+            <p><strong>Total Areas:</strong> ${seedData.areas.filter((a) => tree.clusters.some((c) => c.uid === a.cluster_uid)).length}</p>
+          </div>`;
+      } else if (node.type === 'cluster') {
+        const cluster = getAllClusters().find((c) => c.uid === node.id)!;
+        const areas = seedData.areas.filter((a) => a.cluster_uid === cluster.uid);
+        details = `
+          <h3 class="font-display text-xl font-semibold mb-4">Cluster: ${cluster.name}</h3>
+          <div class="space-y-2">
+            <p><strong>UID:</strong> ${cluster.uid}</p>
+            <p><strong>Status:</strong> <span class="tag-badge ${cluster.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${cluster.status}</span></p>
+            <p><strong>Parent:</strong> ${cluster.parent_id || 'Root'}</p>
+            <p><strong>Children:</strong> ${cluster.children.length}</p>
+            <p><strong>Areas:</strong> ${areas.length}</p>
+            <div class="mt-3">
+              <h4 class="font-semibold mb-2">Areas:</h4>
+              <div class="grid grid-cols-1 gap-2">
+                ${areas
+                  .map(
+                    (area) => `
+                  <div class="border rounded p-2" style="border-color: var(--nf-gray-600);">
+                    <div class="flex justify-between items-center">
+                      <span>${area.name}</span>
+                      <span class="tag-badge ${area.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${area.status}</span>
+                    </div>
+                    <div class="flex flex-wrap gap-1 mt-1">
+                      ${area.tags.map((tag) => `<span class="tag-badge tag-area">${tag}</span>`).join('')}
+                    </div>
+                  </div>`,
+                  )
+                  .join('')}
+              </div>
+            </div>
+          </div>`;
+      } else if (node.type === 'area') {
+        const area = seedData.areas.find((a) => a.uid === node.id)!;
+        details = `
+          <h3 class="font-display text-xl font-semibold mb-4">Area: ${area.name}</h3>
+          <div class="space-y-2">
+            <p><strong>UID:</strong> ${area.uid}</p>
+            <p><strong>Status:</strong> <span class="tag-badge ${area.status === 'active' ? 'tag-status-active' : 'tag-status-inactive'}">${area.status}</span></p>
+            <p><strong>Cluster:</strong> ${area.cluster_uid}</p>
+            <div class="mt-3">
+              <h4 class="font-semibold mb-2">Tags:</h4>
+              <div class="flex flex-wrap gap-1">
+                ${area.tags.map((tag) => `<span class="tag-badge tag-area">${tag}</span>`).join('')}
+              </div>
+            </div>
+          </div>`;
+      }
+
+      content.innerHTML = `${details}<div class="mt-6 flex justify-end"><button class="nf-btn-primary px-4 py-2 rounded-lg" onclick="this.closest('.fixed').remove()">Close</button></div>`;
+      modal.appendChild(content);
+      document.body.appendChild(modal);
+      modal.addEventListener('click', (e) => {
+        if (e.target === modal) modal.remove();
+      });
+    }
+
+    const container = document.getElementById('treeViz') as HTMLElement;
+    if (!container) return;
+
+    const render = () => {
+      container.innerHTML = '';
+      const width = container.clientWidth;
+      const height = 600;
+      const svg = d3.select(container).append('svg').attr('width', width).attr('height', height);
+      const g = svg.append('g').attr('transform', 'translate(50,50)');
+      const treeLayout = d3.tree().size([width - 100, height - 100]);
+      const root = d3.hierarchy(createHierarchicalData());
+      treeLayout(root);
+
+      g.selectAll('.tree-link')
+        .data(root.descendants().slice(1))
+        .enter()
+        .append('path')
+        .attr('class', 'tree-link')
+        .attr('d', (d: any) => `M${d.x},${d.y}C${d.x},${(d.y + d.parent.y) / 2} ${d.parent.x},${(d.y + d.parent.y) / 2} ${d.parent.x},${d.parent.y}`);
+
+      const node = g
+        .selectAll('.tree-node')
+        .data(root.descendants())
+        .enter()
+        .append('g')
+        .attr('class', 'tree-node')
+        .attr('transform', (d: any) => `translate(${d.x},${d.y})`);
+
+      node
+        .append('circle')
+        .attr('r', (d: any) => (d.data.type === 'tree' ? 12 : d.data.type === 'cluster' ? 8 : 6))
+        .style('fill', (d: any) => {
+          if (d.data.type === 'tree') return 'var(--nf-primary-500)';
+          if (d.data.type === 'cluster') return 'var(--nf-accent-cyan)';
+          return 'var(--nf-success)';
+        })
+        .style('stroke', 'var(--nf-gray-400)')
+        .style('stroke-width', '2px');
+
+      node
+        .append('text')
+        .attr('dy', (d: any) => (d.data.type === 'tree' ? -18 : -12))
+        .attr('text-anchor', 'middle')
+        .style('fill', 'var(--nf-gray-200)')
+        .style('font-size', (d: any) => (d.data.type === 'tree' ? '14px' : '12px'))
+        .style('font-weight', (d: any) => (d.data.type === 'tree' ? '600' : '400'))
+        .text((d: any) => d.data.name);
+
+      node
+        .filter((d: any) => d.data.status)
+        .append('circle')
+        .attr('r', 3)
+        .attr('cx', 15)
+        .attr('cy', -8)
+        .style('fill', (d: any) => (d.data.status === 'active' ? 'var(--nf-success)' : 'var(--nf-error)'))
+        .style('stroke', 'var(--nf-gray-800)')
+        .style('stroke-width', '1px');
+
+      node.on('click', (_e: any, d: any) => {
+        showNodeDetails(d.data);
+      });
+    };
+
+    render();
+    window.addEventListener('resize', render);
+    return () => {
+      window.removeEventListener('resize', render);
+    };
+  }, [data, isD3Ready]);
+
+  return (
+    <div className="nf-card rounded-lg p-6 mb-8">
+      <h2 className="font-display text-xl font-semibold mb-4">Tree Structure Visualization</h2>
+      <div id="treeViz" className="w-full" style={{ minHeight: '600px' }}></div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split NightForgeDemo into modular components
- implement ControlsPanel, StatsDashboard, TreeVisualization, TagCloud and DataInspector
- clean up NightForgeDemo to use the new components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f489185083338c417f3ca05b1fd9