### PR TITLE
Refactor TreeVisualization to use refs

### DIFF
--- a/src/components/NightForgeDemo.tsx
+++ b/src/components/NightForgeDemo.tsx
@@ -17,7 +17,6 @@ export default function NightForgeDemo() {
     type: 'all',
     search: '',
   });
-  const [isD3Ready, setIsD3Ready] = useState(false);
 
   const filteredData: FilteredData = useMemo(() => {
     let filteredTrees: any[] = JSON.parse(JSON.stringify(seedData.trees));
@@ -64,16 +63,11 @@ export default function NightForgeDemo() {
     return { trees: filteredTrees, areas: filteredAreas } as FilteredData;
   }, [filters]);
 
-  const handleD3Load = () => {
-    setIsD3Ready(true);
-  };
-
   return (
     <>
       <Script
         src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"
         strategy="afterInteractive"
-        onLoad={handleD3Load}
       />
       <div className="min-h-screen">
         <div className="container mx-auto px-6 py-8 max-w-7xl">
@@ -88,7 +82,7 @@ export default function NightForgeDemo() {
 
           <ControlsPanel filters={filters} setFilters={setFilters} />
           <StatsDashboard data={filteredData} />
-          <TreeVisualization data={filteredData} isD3Ready={isD3Ready} />
+          <TreeVisualization data={filteredData} />
           <TagCloud data={filteredData} filters={filters} setFilters={setFilters} />
           <DataInspector data={filteredData} />
         </div>

--- a/src/components/TreeVisualization.tsx
+++ b/src/components/TreeVisualization.tsx
@@ -1,15 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { FilteredData, TreeNode } from '@/lib/types';
 import { seedData } from '@/lib/seedData';
 
 interface Props {
   data: FilteredData;
-  isD3Ready: boolean;
 }
 
-export default function TreeVisualization({ data, isD3Ready }: Props) {
+export default function TreeVisualization({ data }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
-    if (!isD3Ready) return;
     const d3 = (window as any).d3;
     if (!d3) return;
 
@@ -128,11 +128,11 @@ export default function TreeVisualization({ data, isD3Ready }: Props) {
       });
     }
 
-    const container = document.getElementById('treeViz') as HTMLElement;
+    const container = containerRef.current;
     if (!container) return;
 
     const render = () => {
-      container.innerHTML = '';
+      d3.select(container).selectAll('*').remove();
       const width = container.clientWidth;
       const height = 600;
       const svg = d3.select(container).append('svg').attr('width', width).attr('height', height);
@@ -195,13 +195,18 @@ export default function TreeVisualization({ data, isD3Ready }: Props) {
     window.addEventListener('resize', render);
     return () => {
       window.removeEventListener('resize', render);
+      d3.select(container).selectAll('*').remove();
     };
-  }, [data, isD3Ready]);
+  }, [data]);
 
   return (
     <div className="nf-card rounded-lg p-6 mb-8">
       <h2 className="font-display text-xl font-semibold mb-4">Tree Structure Visualization</h2>
-      <div id="treeViz" className="w-full" style={{ minHeight: '600px' }}></div>
+      <div
+        ref={containerRef}
+        className="w-full"
+        style={{ minHeight: '600px' }}
+      ></div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- migrate DOM lookups to useRef based updates
- trigger D3 rendering in useEffect when filtered data changes
- simplify NightForgeDemo by removing script onLoad handling

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f60193c08333a7297759073a1632