### PR TITLE
Improve modal accessibility and colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,8 +11,8 @@
   --nf-gray-400: #6b7287;
   --nf-gray-200: #b7bbd0;
   --nf-gray-100: #e7e9f6;
-  --nf-primary-500: #7f5cff;
-  --nf-primary-300: #b39afe;
+  --nf-primary-500: #6540ff;
+  --nf-primary-300: #7652ff;
   --nf-primary-700: #5941c6;
   --nf-accent-cyan: #22d6f3;
   --nf-accent-pink: #ff4f9c;

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -98,6 +98,7 @@ export default function ControlsPanel({ filters, setFilters }: Props) {
           type="text"
           id="searchInput"
           placeholder="Search tags, clusters, areas..."
+          aria-label="Search"
           className="px-4 py-2 rounded-lg border flex-1"
           style={{
             background: "var(--nf-gray-700)",

--- a/src/components/TreeVisualization.tsx
+++ b/src/components/TreeVisualization.tsx
@@ -66,10 +66,15 @@ export default function TreeVisualization({ data, isD3Ready }: Props) {
     }
 
     function showNodeDetails(node: any) {
+      const previouslyFocused = document.activeElement as HTMLElement | null;
+
       const modal = document.createElement("div");
       modal.className =
         "fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50";
       modal.style.backdropFilter = "blur(8px)";
+      modal.setAttribute("role", "dialog");
+      modal.setAttribute("aria-modal", "true");
+      modal.tabIndex = -1;
 
       const content = document.createElement("div");
       content.className =
@@ -137,12 +142,41 @@ export default function TreeVisualization({ data, isD3Ready }: Props) {
           </div>`;
       }
 
-      content.innerHTML = `${details}<div class="mt-6 flex justify-end"><button class="nf-btn-primary px-4 py-2 rounded-lg" onclick="this.closest('.fixed').remove()">Close</button></div>`;
+      content.innerHTML = details;
+
+      const actions = document.createElement("div");
+      actions.className = "mt-6 flex justify-end";
+      const closeBtn = document.createElement("button");
+      closeBtn.className = "nf-btn-primary px-4 py-2 rounded-lg";
+      closeBtn.textContent = "Close";
+      closeBtn.setAttribute("aria-label", "Close dialog");
+      actions.appendChild(closeBtn);
+      content.appendChild(actions);
+
       modal.appendChild(content);
       document.body.appendChild(modal);
+
+      const closeModal = () => {
+        modal.remove();
+        document.removeEventListener("keydown", handleKey);
+        if (previouslyFocused) previouslyFocused.focus();
+      };
+
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          closeModal();
+        }
+      };
+
+      document.addEventListener("keydown", handleKey);
+      closeBtn.addEventListener("click", closeModal);
+
       modal.addEventListener("click", (e) => {
-        if (e.target === modal) modal.remove();
+        if (e.target === modal) closeModal();
       });
+
+      setTimeout(() => closeBtn.focus(), 0);
     }
 
     const container = document.getElementById("treeViz") as HTMLElement;


### PR DESCRIPTION
## Summary
- update modal with ARIA attributes, focus management, and Escape handling
- add `aria-label` for the search input
- adjust primary colors for sufficient contrast

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685809bd502483338d10c79dda734a6e